### PR TITLE
View Partner's profile with quicktabs

### DIFF
--- a/config/sync/block.block.quicktabspartnercontent.yml
+++ b/config/sync/block.block.quicktabspartnercontent.yml
@@ -1,29 +1,24 @@
-uuid: 2a3fe5a5-ed09-4813-abc2-6ad431f67612
+uuid: 8858b6f8-fc34-49da-98c5-8237bc0475b3
 langcode: en
-status: false
+status: true
 dependencies:
-  config:
-    - views.view.country_partner_content
   module:
     - context
+    - quicktabs
     - system
-    - views
   theme:
     - oira_theme
-id: views_block__country_partner_content_block_5
+id: quicktabspartnercontent
 theme: oira_theme
 region: content
-weight: -8
+weight: 0
 provider: null
-plugin: 'views_block:country_partner_content-block_5'
+plugin: 'quicktabs_block:partner_content'
 settings:
-  id: 'views_block:country_partner_content-block_5'
-  label: ''
-  provider: views
-  label_display: visible
-  views_label: ''
-  items_per_page: none
-  context_mapping: {  }
+  id: 'quicktabs_block:partner_content'
+  label: 'QuickTabs - Partner Content'
+  provider: quicktabs
+  label_display: '0'
 visibility:
   request_path_exclusion:
     id: request_path_exclusion

--- a/config/sync/block.block.views_block__country_partner_content_block_3.yml
+++ b/config/sync/block.block.views_block__country_partner_content_block_3.yml
@@ -1,6 +1,6 @@
 uuid: f24ebefa-bfcf-4734-9248-05d8ba558f95
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.country_partner_content

--- a/config/sync/block.block.views_block__country_partner_content_block_4.yml
+++ b/config/sync/block.block.views_block__country_partner_content_block_4.yml
@@ -1,6 +1,6 @@
 uuid: a74a86e4-e6e9-4a16-bf42-dd3f76589f6b
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.country_partner_content

--- a/config/sync/core.entity_view_display.media.resource_fc.media_library.yml
+++ b/config/sync/core.entity_view_display.media.resource_fc.media_library.yml
@@ -10,18 +10,28 @@ dependencies:
     - media.type.resource_fc
   module:
     - file
-    - image
+    - languagefield
     - link
 id: media.resource_fc.media_library
 targetEntityType: media
 bundle: resource_fc
 mode: media_library
 content:
-  field_link:
-    type: link
+  field_language:
+    type: languagefield_default
     weight: 0
     region: content
-    label: above
+    label: hidden
+    settings:
+      link_to_entity: false
+      format:
+        name: name
+    third_party_settings: {  }
+  field_link:
+    type: link
+    weight: 1
+    region: content
+    label: hidden
     settings:
       trim_length: 80
       url_only: false
@@ -31,28 +41,19 @@ content:
     third_party_settings: {  }
   field_media_file:
     type: file_default
-    weight: 1
-    region: content
-    label: above
-    settings:
-      use_description_as_link_text: true
-    third_party_settings: {  }
-  thumbnail:
-    type: image
     weight: 2
     region: content
     label: hidden
     settings:
-      image_style: ''
-      image_link: ''
+      use_description_as_link_text: true
     third_party_settings: {  }
 hidden:
   created: true
   entity_print_view_epub: true
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
-  field_language: true
   langcode: true
   name: true
   search_api_excerpt: true
+  thumbnail: true
   uid: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -99,6 +99,7 @@ module:
   path: 0
   path_alias: 0
   quickedit: 0
+  quicktabs: 0
   rdf: 0
   rest: 0
   search: 0

--- a/config/sync/language/ro/metatag.metatag_defaults.node.yml
+++ b/config/sync/language/ro/metatag.metatag_defaults.node.yml
@@ -1,0 +1,1 @@
+label: Content

--- a/config/sync/language/ro/views.view.tmgmt_job_items.yml
+++ b/config/sync/language/ro/views.view.tmgmt_job_items.yml
@@ -18,8 +18,12 @@ display:
       fields:
         label:
           label: Label
+        type:
+          label: Type
         tags_count:
           label: Etichete
+        operations:
+          label: Operations
       arguments:
         tjid:
           exception:
@@ -29,3 +33,5 @@ display:
       fields:
         label:
           label: Label
+        type:
+          label: Type

--- a/config/sync/language/ro/views.view.tmgmt_job_overview.yml
+++ b/config/sync/language/ro/views.view.tmgmt_job_overview.yml
@@ -20,3 +20,5 @@ display:
           label: Label
         tags_count:
           label: Etichete
+        operations:
+          label: Operations

--- a/config/sync/language/ro/views.view.tmgmt_translation_all_job_items.yml
+++ b/config/sync/language/ro/views.view.tmgmt_translation_all_job_items.yml
@@ -23,5 +23,15 @@ display:
       fields:
         label:
           label: Label
+        type:
+          label: Type
         tags_count:
           label: Etichete
+        operations:
+          label: Operations
+      filters:
+        job_type:
+          group_info:
+            group_items:
+              1:
+                title: Normal

--- a/config/sync/language/ro/webform.settings.yml
+++ b/config/sync/language/ro/webform.settings.yml
@@ -1,3 +1,6 @@
 settings:
   default_reset_button_label: Resetează
   default_delete_button_label: Delete
+  dialog_options:
+    normal:
+      title: Normal

--- a/config/sync/language/ro/webform.webform_options.languages.yml
+++ b/config/sync/language/ro/webform.webform_options.languages.yml
@@ -1,1 +1,0 @@
-label: Languages

--- a/config/sync/quicktabs.quicktabs_instance.partner_content.yml
+++ b/config/sync/quicktabs.quicktabs_instance.partner_content.yml
@@ -1,0 +1,107 @@
+uuid: 8315b6b0-78c4-4e4d-87cd-487898b6bc89
+langcode: en
+status: true
+dependencies: {  }
+id: partner_content
+label: 'Partner Content'
+renderer: quick_tabs
+options:
+  quick_tabs:
+    class: ''
+    style: tabsbar
+    ajax: false
+hide_empty_tabs: true
+default_tab: 0
+configuration_data:
+  -
+    title: 'Show all'
+    weight: -10
+    type: view_content
+    content:
+      block_content:
+        options:
+          bid: addtoany_block
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: country_partner_content
+          display: block_1
+          args: ''
+      qtabs_content:
+        options:
+          machine_name: ''
+  -
+    title: 'OiRA Tools'
+    weight: -9
+    type: view_content
+    content:
+      block_content:
+        options:
+          bid: addtoany_block
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: country_partner_content
+          display: block_3
+          args: ''
+      qtabs_content:
+        options:
+          machine_name: ''
+  -
+    title: 'Promotional resources'
+    weight: -8
+    type: view_content
+    content:
+      block_content:
+        options:
+          bid: addtoany_block
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: country_partner_content
+          display: block_5
+          args: ''
+      qtabs_content:
+        options:
+          machine_name: ''
+  -
+    title: News
+    weight: -7
+    type: view_content
+    content:
+      block_content:
+        options:
+          bid: addtoany_block
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: country_partner_content
+          display: block_4
+          args: ''
+      qtabs_content:
+        options:
+          machine_name: ''

--- a/config/sync/views.view.country_partner_content.yml
+++ b/config/sync/views.view.country_partner_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.media.field_language
     - field.storage.media.field_link
+    - field.storage.media.field_media_file
     - field.storage.node.body
     - field.storage.node.field_alternative_body
     - field.storage.node.field_country
@@ -17,6 +18,7 @@ dependencies:
     - field.storage.node.field_sector_category
     - field.storage.node.field_summary
     - field.storage.node.field_tool_link
+    - image.style.media_library
     - image.style.medium
     - image.style.thumbnail
     - node.type.news
@@ -26,6 +28,7 @@ dependencies:
   module:
     - content_moderation
     - datetime
+    - file
     - languagefield
     - link
     - media
@@ -643,6 +646,8 @@ display:
         style: false
         row: false
         query: false
+        pager: false
+        group_by: false
       title: 'Partner content - profile page'
       relationships:
         field_co_author_node:
@@ -663,6 +668,15 @@ display:
           admin_label: 'field_related_partners: Content'
           required: false
           plugin_id: standard
+        field_resource_fc:
+          id: field_resource_fc
+          table: node__field_resource_fc
+          field: field_resource_fc
+          relationship: none
+          group_type: group
+          admin_label: 'field_resource_fc: Media'
+          required: false
+          plugin_id: standard
       fields:
         type:
           id: type
@@ -672,7 +686,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -716,6 +730,216 @@ display:
           type: entity_reference_label
           settings:
             link: false
+          group_column: entity_id
+          group_columns:
+            bundle: bundle
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: null
+          group_columns: null
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_image:
+          id: field_image
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: media_library
+            image_link: ''
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -726,8 +950,70 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
+          plugin_id: field
+        field_image_1:
+          id: field_image_1
+          table: node__field_image
+          field: field_image
+          relationship: none
+          group_type: group
+          admin_label: 'image news'
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: media_library
+            image_link: content
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
           plugin_id: field
         field_revised_date:
           id: field_revised_date
@@ -737,7 +1023,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -857,135 +1143,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: h3
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: field
         field_sector_category:
           id: field_sector_category
           table: node__field_sector_category
@@ -1049,15 +1206,505 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        field_image:
-          id: field_image
-          table: node__field_image
-          field: field_image
+        field_country:
+          id: field_country
+          table: node__field_country
+          field: field_country
           relationship: none
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_promotional_material_type:
+          id: field_promotional_material_type
+          table: node__field_promotional_material_type
+          field: field_promotional_material_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_language:
+          id: field_language
+          table: node__field_language
+          field: field_language
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: languagefield_default
+          settings:
+            link_to_entity: 0
+            format:
+              name: name
+              iso: 0
+              name_native: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_summary:
+          id: field_summary
+          table: node__field_summary
+          field: field_summary
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_tool_link:
+          id: field_tool_link
+          table: node__field_tool_link
+          field: field_tool_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: 'Access the tool'
+            make_link: true
+            path: '{{ field_tool_link__uri }}'
+            absolute: false
+            external: true
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: _blank
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        view_node:
+          id: view_node
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'See more'
+          output_url_as_text: false
+          absolute: false
+          entity_type: node
+          plugin_id: entity_link
+        view_node_1:
+          id: view_node_1
+          table: node
+          field: view_node
+          relationship: field_related_partners
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: '> See partner''s profile'
+          output_url_as_text: false
+          absolute: false
+          entity_type: node
+          plugin_id: entity_link
+        field_logo:
+          id: field_logo
+          table: node__field_logo
+          field: field_logo
+          relationship: field_related_partners
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1100,8 +1747,8 @@ display:
           click_sort_column: target_id
           type: media_thumbnail
           settings:
-            image_style: medium
-            image_link: ''
+            image_style: media_library
+            image_link: content
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1113,47 +1760,500 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-      filters:
-        status:
-          id: status
+        title_1:
+          id: title_1
           table: node_field_data
-          field: status
+          field: title
+          relationship: field_related_partners
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        view_node_2:
+          id: view_node_2
+          table: node
+          field: view_node
+          relationship: field_co_author_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: '> See partner''s profile'
+          output_url_as_text: false
+          absolute: false
+          entity_type: node
+          plugin_id: entity_link
+        field_logo_1:
+          id: field_logo_1
+          table: node__field_logo
+          field: field_logo
+          relationship: field_co_author_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: media_thumbnail
+          settings:
+            image_style: media_library
+            image_link: content
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title_2:
+          id: title_2
+          table: node_field_data
+          field: title
+          relationship: field_co_author_node
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_media_file:
+          id: field_media_file
+          table: media__field_media_file
+          field: field_media_file
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: file_default
+          settings:
+            use_description_as_link_text: true
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_language_1:
+          id: field_language_1
+          table: media__field_language
+          field: field_language
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: languagefield_default
+          settings:
+            link_to_entity: 0
+            format:
+              name: name
+              iso: 0
+              name_native: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_link:
+          id: field_link
+          table: media__field_link
+          field: field_link
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
           relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: "<div class=\"view-show-all\">\r\n\r\n<div class=\"group-left\">\r\n    {% if type != \"News\" %}<div class=\"views-field views-field-field-image\">{{ field_image }}</div>{% endif %}\r\n    {% if (type == \"News\") %}<div class=\"views-field views-field-field-image\">{{ field_image_1 }}</div> {% endif %}\r\n</div>\r\n\r\n<div class=\"group-right\">\r\n  \r\n  {% if (type) == \"OiRA Tools\" %}\r\n   <div class=\"revised-date\">{{ field_revised_date }}</div>\r\n   <div class=\"tags\">\r\n    <p class=\"tag tag-sector\"> {{ field_sector_category }}</p>\r\n    <p class=\"tag tag-country\"> {{ field_country }} </p>\r\n    {{ field_language}}\r\n  </div>\r\n  <div class=\"title title-tool\"><h3>{{title}}</h3></div>\r\n  <div class=\"body body-tool\">{{body}}</div>\r\n  <div class=\"tool-link\"> {{ field_tool_link }} </div>\r\n  <div class=\"expandible\">\r\n     <div class=\"partners-wrapper\">\r\n\r\n      {% if (title_1) %}\r\n      <div class=\"partner-wrapper partner-wrapper-related\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n         {{field_logo}}\r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n          <h4>{{ title_1 }}</h4>\r\n          {{view_node_1 }} \r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n  \r\n      {% if (title_2)%}\r\n      <div class=\"partner-wrapper partner-wrapper-co-author\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n          {{ field_logo_1 }} \r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n           <h4>{{ title_2 }}</h4>\r\n           {{ view_node_2 }}\r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n      \r\n    </div> \r\n\r\n    <span class=\"more-link\"> See more</span>\r\n  </div>\r\n  {% endif %}\r\n\r\n    {% if (type) == \"Promotional resources\" %}\r\n    <div class=\"revised-date\">{{ field_revised_date }}</div>\r\n    <div class=\"tags\">\r\n    <p class=\"tag tag-country\"> {{ field_country }} </p>\r\n    <p class=\"tag tag-type\"> {{ field_promotional_material_type }} </p>\r\n    {{ field_language_1}}\r\n  </div>\r\n  <div class=\"title title-pm\"><h3>{{title}}</h3></div>\r\n  <div class=\"body body-pm\">{{body}}</div>\r\n  <div class=\"res-file\">{{ field_media_file }} </div>\r\n   <div class=\"res-link\">{{ field_link}} </div>\r\n<div class=\"expandible\">\r\n     \r\n    <div class=\"partners-wrapper\">\r\n\r\n      {% if (title_1) %}\r\n      <div class=\"partner-wrapper partner-wrapper-related\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n         {{field_logo}}\r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n          <h4>{{ title_1 }}</h4>\r\n          {{view_node_1 }} \r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n  \r\n      {% if (title_2)%}\r\n      <div class=\"partner-wrapper partner-wrapper-co-author\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n          {{ field_logo_1 }} \r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n           <h4>{{ title_2 }}</h4>\r\n           {{ view_node_2 }}\r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n      \r\n    </div> \r\n\r\n    <span class=\"more-link\"> See more</span>\r\n</div>\r\n  {% endif %}\r\n\r\n   {%if (type == \"News\")%}\r\n    <div class=\"publication-date\">{{ field_publication_date }}</div>\r\n    <div class=\"title title-new\"><h3>{{title}}</h3></div>\r\n    <div class=\"summary\"> {{field_summary}}</div>\r\n    <span class=\"see-more\">{{ view_node }}</span>\r\n   {% endif %}\r\n</div>\r\n\r\n</div>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+          plugin_id: custom
+      filters:
         type:
           id: type
           table: node_field_data
@@ -1163,6 +2263,9 @@ display:
           admin_label: ''
           operator: in
           value:
+            min: ''
+            max: ''
+            value: ''
             news: news
             practical_tool: practical_tool
             promotional_material: promotional_material
@@ -1182,6 +2285,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
             reduce: false
           is_grouped: false
           group_info:
@@ -1272,25 +2378,16 @@ display:
           not: false
           plugin_id: numeric
       block_description: 'block content related partner'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: 'Lo que sea'
-            format: basic_html
-          plugin_id: text
+      header: {  }
       style:
         type: default
         options:
-          grouping: {  }
-          row_class: container
+          grouping:
+            -
+              field: type
+              rendered: true
+              rendered_strip: false
+          row_class: container-fluid
           default_row_class: true
       row:
         type: fields
@@ -1305,6 +2402,11 @@ display:
           query_comment: ''
           query_tags: null
           contextual_filters_or: 1
+      pager:
+        type: none
+        options:
+          offset: 0
+      group_by: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -1314,10 +2416,20 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.media.field_language'
+        - 'config:field.storage.media.field_link'
+        - 'config:field.storage.media.field_media_file'
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_country'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_language'
+        - 'config:field.storage.node.field_logo'
+        - 'config:field.storage.node.field_promotional_material_type'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_revised_date'
         - 'config:field.storage.node.field_sector_category'
+        - 'config:field.storage.node.field_summary'
+        - 'config:field.storage.node.field_tool_link'
   block_2:
     display_plugin: block
     id: block_2
@@ -3306,6 +4418,7 @@ display:
         style: false
         row: false
         query: false
+        group_by: false
       title: 'Promotional resources'
       relationships:
         field_co_author_node:
@@ -3590,73 +4703,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        field_language_1:
-          id: field_language_1
-          table: media__field_language
-          field: field_language
-          relationship: field_resource_fc
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: languagefield_default
-          settings:
-            link_to_entity: 0
-            format:
-              name: name
-              iso: 0
-              name_native: 0
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -3773,73 +4819,6 @@ display:
           settings:
             trim_length: 600
           group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        field_link:
-          id: field_link
-          table: media__field_link
-          field: field_link
-          relationship: field_resource_fc
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: uri
-          type: link
-          settings:
-            trim_length: 80
-            url_only: false
-            url_plain: false
-            rel: '0'
-            target: '0'
-          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -4214,6 +5193,203 @@ display:
           absolute: false
           entity_type: node
           plugin_id: entity_link
+        field_media_file:
+          id: field_media_file
+          table: media__field_media_file
+          field: field_media_file
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: file_default
+          settings:
+            use_description_as_link_text: true
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_language:
+          id: field_language
+          table: media__field_language
+          field: field_language
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: languagefield_default
+          settings:
+            link_to_entity: 0
+            format:
+              name: name
+              iso: 0
+              name_native: 0
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_link:
+          id: field_link
+          table: media__field_link
+          field: field_link
+          relationship: field_resource_fc
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         nothing:
           id: nothing
           table: views
@@ -4225,7 +5401,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"group-left\">\r\n  <div class=\"views-field views-field-field-image\">{{ field_image }}</div>\r\n</div>\r\n\r\n<div class=\"group-right\">\r\n  <div class=\"field-revised-date\"> {{ field_revised_date }} </div>\r\n  <div class=\"tags\">\r\n    <p class=\"tag-country\"> {{ field_country }} </p>\r\n    <p class=\"tag-type\"> {{ field_promotional_material_type }}  </p>\r\n    {{ field_language_1}}\r\n  </div>\r\n  <div class=\"pm-title\"> {{title}} </div>\r\n  <div class=\"pm-body\"> {{body}}  </div>\r\n  <div class=\"res-link\"> {{ field_link }} </div>\r\n\r\n  <div class=\"expandible\">\r\n     <div class=\"partners-wrapper\">\r\n\r\n        {% if (title_1) %}\r\n        <div class=\"partner-wrapper partner-wrapper-related\">\r\n          <div class=\"partner-inner-group partner-inner-group--img\">\r\n            {{field_logo}}\r\n          </div>\r\n          <div class=\"partner-inner-group partner-inner-group--data\">\r\n            <h4>{{ title_1 }}</h4>\r\n            {{ view_node }} \r\n          </div>\r\n      </div>\r\n      {% endif %}\r\n  \r\n      {% if (title_2)%}\r\n      <div class=\"partner-wrapper partner-wrapper-co-author\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n          {{ field_logo_1 }} \r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n           <h4>{{ title_2 }}</h4>\r\n           {{ view_node_1 }}\r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n\r\n      </div> \r\n  </div>\r\n\r\n  <span class=\"more-link\"> See more </span>\r\n\r\n</div>"
+            text: "<div class=\"group-left\">\r\n  <div class=\"views-field views-field-field-image\">{{ field_image }}</div>\r\n</div>\r\n\r\n<div class=\"group-right\">\r\n  <div class=\"field-revised-date\"> {{ field_revised_date }} </div>\r\n  <div class=\"tags\">\r\n    <p class=\"tag-country\"> {{ field_country }} </p>\r\n    <p class=\"tag-type\"> {{ field_promotional_material_type }}  </p>\r\n    {{ field_language}}\r\n  </div>\r\n  <div class=\"pm-title\"> {{title}} </div>\r\n  <div class=\"pm-body\"> {{body}}  </div>\r\n  <div class=\"res-link\"> {{ field_link }} </div>\r\n  <div class=\"res-file\"> {{ field_media_file }} </div>\r\n  <div class=\"expandible\">\r\n     <div class=\"partners-wrapper\">\r\n\r\n        {% if (title_1) %}\r\n        <div class=\"partner-wrapper partner-wrapper-related\">\r\n          <div class=\"partner-inner-group partner-inner-group--img\">\r\n            {{field_logo}}\r\n          </div>\r\n          <div class=\"partner-inner-group partner-inner-group--data\">\r\n            <h4>{{ title_1 }}</h4>\r\n            {{ view_node }} \r\n          </div>\r\n      </div>\r\n      {% endif %}\r\n  \r\n      {% if (title_2)%}\r\n      <div class=\"partner-wrapper partner-wrapper-co-author\">\r\n        <div class=\"partner-inner-group partner-inner-group--img\">\r\n          {{ field_logo_1 }} \r\n        </div>\r\n        <div class=\"partner-inner-group partner-inner-group--data\">\r\n           <h4>{{ title_2 }}</h4>\r\n           {{ view_node_1 }}\r\n        </div>\r\n      </div>\r\n      {% endif %}\r\n\r\n      </div> \r\n  </div>\r\n\r\n  <span class=\"more-link\"> See more </span>\r\n\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -4446,11 +5622,12 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
-          query_tags: null
+          query_tags: {  }
           contextual_filters_or: 1
+      group_by: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -4462,6 +5639,7 @@ display:
       tags:
         - 'config:field.storage.media.field_language'
         - 'config:field.storage.media.field_link'
+        - 'config:field.storage.media.field_media_file'
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_country'
         - 'config:field.storage.node.field_image'


### PR DESCRIPTION
Enable module quicktabs
Add quicktab partner content and configure it.
Place quicktab as block in content.
Update view country_partner_content all displays to work with tabs.
This view needs to be revised and fixed so the content type promotional resource does not appear repeated.
Please read this: https://docs.google.com/document/d/12AuUL5SQGqkqjYqr3Ptr-KHPLLK9NB8-JmclTN6i1XY/edit
